### PR TITLE
fix: use non-breakable spaces for filesize

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
 
-const filesize = require('filesize')
+const originalFilesize = require('filesize')
 const numberToWords = require('number-to-words')
 const fs = require('fs')
 const path = require('path')
 const { getBuildOutputDirectory, getOptions } = require('./utils')
+
+// Override default filesize options to display a non-breakable space as a spacer.
+const filesize = (bytes, options) => {
+  return originalFilesize(bytes, {
+    spacer: ' ',
+    ...options,
+  })
+}
 
 // Pull options from `package.json`
 const options = getOptions()


### PR DESCRIPTION
Not a huge deal, but this overrides the default `filesize` spacer from a regular space to a non-breaking one.

Before:
<img width="829" alt="Screenshot 2022-02-23 at 12 37 07 PM" src="https://user-images.githubusercontent.com/166147/155312165-152c368a-7239-4e78-bb3e-b70332a651fa.png">

After:
<img width="829" alt="Screenshot 2022-02-23 at 12 37 43 PM" src="https://user-images.githubusercontent.com/166147/155312254-8eb6f945-b6c5-4a36-826c-0ef92f6ea4bc.png">

