### PR TITLE
feat: add ability to specify minimum change threshold

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -42,17 +42,23 @@ delete currentBundle.__global
 delete baseBundle.__global
 
 // calculate the difference between the current bundle and the base branch's
-const globalBundleChanges =
-  globalBundleCurrent.gzip !== globalBundleBase.gzip
-    ? {
-        page: 'global',
-        raw: globalBundleCurrent.raw,
-        gzip: globalBundleCurrent.gzip,
-        gzipDiff: globalBundleCurrent.gzip - globalBundleBase.gzip,
-        increase:
-          Math.sign(globalBundleCurrent.gzip - globalBundleBase.gzip) > 0,
-      }
-    : false
+let globalBundleChanges = false
+const globalGzipDiff = globalBundleCurrent.gzip - globalBundleBase.gzip
+// only report a global bundle size change if we don't have a minimum change
+// threshold configured, or if the change is greater than the threshold
+if (
+  globalGzipDiff !== 0 &&
+  (!('minimumChangeThreshold' in options) ||
+    Math.abs(globalGzipDiff) > options.minimumChangeThreshold)
+) {
+  globalBundleChanges = {
+    page: 'global',
+    raw: globalBundleCurrent.raw,
+    gzip: globalBundleCurrent.gzip,
+    gzipDiff: globalGzipDiff,
+    increase: Math.sign(globalGzipDiff) > 0,
+  }
+}
 
 // now we're going to go through each of the pages in the current bundle and
 // run analysis on each one.
@@ -74,7 +80,14 @@ for (let page in currentBundle) {
     const rawDiff = currentStats.raw - baseStats.raw
     const gzipDiff = currentStats.gzip - baseStats.gzip
     const increase = !!Math.sign(gzipDiff)
-    changedPages.push({ page, ...currentStats, rawDiff, gzipDiff, increase })
+    // only report a page size change if we don't have a minimum change
+    // threshold configured, or if the change is greater than the threshold
+    if (
+      !('minimumChangeThreshold' in options) ||
+      Math.abs(gzipDiff) > options.minimumChangeThreshold
+    ) {
+      changedPages.push({ page, ...currentStats, rawDiff, gzipDiff, increase })
+    }
   }
 }
 

--- a/generate.js
+++ b/generate.js
@@ -28,6 +28,12 @@ inquirer
         'If you exceed this percentage of the budget or filesize, it will be highlighted in red',
       default: 20,
     },
+    {
+      type: 'number',
+      name: 'minimumChangeThreshold',
+      message: `If a page's size change is below this threshold (in bytes), it will be considered unchanged'`,
+      default: 0,
+    },
   ])
   .then((answers) => {
     // write the config values to package.json
@@ -36,6 +42,7 @@ inquirer
     packageJsonContent.nextBundleAnalysis = {
       budget: answers.budget * 1024,
       budgetPercentIncreaseRed: answers.redIndicatorPercentage,
+      minimumChangeThreshold: answers.minimumChangeThreshold,
       showDetails: true, // add a default "showDetails" argument
     }
     fs.writeFileSync(


### PR DESCRIPTION
Inspired by [preactjs/compressed-size-action](https://github.com/preactjs/compressed-size-action#increasing-the-required-threshold), this PR adds a new configuration option `minimumChangeThreshold` to hide pages that have changes below the configured threshold.

By default, the threshold is `0`, meaning any changes to the global bundle size or the size of a page will cause them to be included in the report.