### PR TITLE
Run comparison against branch base

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -58,7 +58,7 @@ jobs:
         if: success() && github.event.number
         with:
           workflow: nextjs_bundle_analysis.yml
-          branch: ${{ github.event.pull_request.base.ref }}
+          commit: ${{ github.event.pull_request.base.sha }}
           path: .next/analyze/base
 
       # And here's the second place - this runs after we have both the current and


### PR DESCRIPTION
The existing template sets up a comparison against the _latest_ bundle analysis on the target branch. But that misrepresents the effect of the current PR. The current PR might have no effect on bundle sizes but they have changed in the meantime on the target branch for some unrelated reason, and then the comparison will suggest that the current PR is having the inverse effect.

So instead, default to running the comparison against the bundle analysis on `github.event.pull_request.base.sha`, which is the latest commit on the target branch that is also an ancestor of the tip of the PR branch (either by being the original commit from which the PR branch was forked, or the latest commit on the target branch that has been merged into the PR branch).