### PR TITLE
Run a version that is up-to-date with the README

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -45,7 +45,7 @@ jobs:
       # Here's the first place where next-bundle-analysis' own script is used
       # This step pulls the raw bundle stats for the current bundle
       - name: Analyze bundle
-        run: npx -p nextjs-bundle-analysis report
+        run: npx -y -p github:hashicorp/nextjs-bundle-analysis#edcf9852e492ce5bdef321ea9d4eae33a74e0991 report
 
       - name: Upload bundle
         uses: actions/upload-artifact@v2
@@ -76,7 +76,7 @@ jobs:
       # entry in your package.json file.
       - name: Compare with base branch bundle
         if: success() && github.event.number
-        run: ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis compare
+        run: ls -laR .next/analyze/base && npx -y -p github:hashicorp/nextjs-bundle-analysis#edcf9852e492ce5bdef321ea9d4eae33a74e0991 compare
 
       - name: Get comment body
         id: get-comment-body


### PR DESCRIPTION
By default generate a job configuration that executes the up-to-date version of the code.

Or alternatively just release a new version. The current release is from February and predates the `minimumChangeThreshold` setting documented in the README, so [the current situation wastes people's time troubleshooting why that setting doesn't work](https://github.com/hashicorp/nextjs-bundle-analysis/issues/25). :-)