### PR TITLE
fix: use actions/github-script to set comment body

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -81,12 +81,13 @@ jobs:
       - name: Get comment body
         id: get-comment-body
         if: success() && github.event.number
-        run: |
-          body=$(cat .next/analyze/__bundle_analysis_comment.txt)
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo ::set-output name=body::$body
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('fs')
+            const comment = fs.readFileSync('.next/analyze/__bundle_analysis_comment.txt', 'utf8')
+            core.setOutput('body', comment)
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1


### PR DESCRIPTION
Setting action output using `::set-output` was deprecated on 11th Oct 2022. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ I've tried several approaches to switch to the new variant, but all of them have some kind of issues with multiline strings. So I tried something completely different and implemented it using `actions/github-script`.