### PR TITLE
Add a note for using with app in subdirectory

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -10,6 +10,8 @@ on:
 defaults:
   run:
     # change this if your nextjs app does not live at the root of the repo
+    # note: this only affects `run` steps, so you also need to adjust the
+    # paths in `uses` steps
     working-directory: ./
 
 jobs:
@@ -34,6 +36,7 @@ jobs:
         with:
           # if you use a custom build directory, replace all instances of `.next` in this file with your build directory
           # ex: if your app builds to `dist`, replace `.next` with `dist`
+          # also, prefix this with your app directory if it's not at the root
           path: .next/cache
           # change this if you prefer a more strict cache
           key: ${{ runner.os }}-build-${{ env.cache-name }}
@@ -51,6 +54,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: bundle
+          # prefix this with your app directory if it's not at the root
           path: .next/analyze/__bundle_analysis.json
 
       - name: Download base branch bundle stats
@@ -59,6 +63,7 @@ jobs:
         with:
           workflow: nextjs_bundle_analysis.yml
           branch: ${{ github.event.pull_request.base.ref }}
+          # prefix this with your app directory if it's not at the root
           path: .next/analyze/base
 
       # And here's the second place - this runs after we have both the current and


### PR DESCRIPTION
Hi! Our team recently moved to using a monorepo so our Next.js app was no longer in the root directory of the repo.

According to the comment for `defaults.run.working-directory` I updated that to point to the subdir our app lives in, but this didn't work - on `main` no artifacts were found to be uploaded, and then branch builds would fail because they had nothing to compare against.

It turns out `defaults.run.working-directory` only affects `run` steps, but `uses` steps will still run from the root! This means the paths given to `uses: actions/cache@v2`, `uses: actions/upload-artifact@v2` and `uses: dawidd6/action-download-artifact@v2` also need to be prefixed with the app subdirectory.

This PR adds comments to make this more obvious. Cheers! 