### PR TITLE
Add permission for PR comments

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -12,6 +12,11 @@ defaults:
     # change this if your nextjs app does not live at the root of the repo
     working-directory: ./
 
+permissions:
+  contents: read # for checkout repository
+  actions: read # for fetching base branch bundle stats
+  pull-requests: write # for comments
+
 jobs:
   analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
PRs created by Dependabot and others may cause the Action to fail due to lack of permission.
Therefore, you should explicitly set the permissions.


> By default, GitHub Actions workflows triggered by Dependabot get a `GITHUB_TOKEN` with read-only permissions.

*https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions*