### PR TITLE
Replaces node v14 with node v18

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up node
-        uses: actions/setup-node@v1
+      - name: Install Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 18
 
       - name: Install dependencies
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
Move from node v14 which is not current anymore to v18 which is the current active LTS.

I tested it and it's working on my website.