### PR TITLE
Support pnpm

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 
-      # If pnpm is used, you need to switch the previous step with the following one. pnpm does not create a packages-lock.file
+      # If pnpm is used, you need to switch the previous step with the following one. pnpm does not create a package-lock.json
       # so the step above will fail to pull dependencies
       # - uses: pnpm/action-setup@v2
       #   name: Install pnpm

--- a/template.yml
+++ b/template.yml
@@ -26,6 +26,15 @@ jobs:
       - name: Install dependencies
         uses: bahmutov/npm-install@v1
 
+      # If pnpm is used, you need to switch the previous step with the following one. pnpm does not create a packages-lock.file
+      # so the step above will fail to pull dependencies
+      # - uses: pnpm/action-setup@v2
+      #   name: Install pnpm
+      #   id: pnpm-install
+      #   with:
+      #     version: 7
+      #     run_install: true
+
       - name: Restore next build
         uses: actions/cache@v2
         id: restore-build-cache


### PR DESCRIPTION
This change contains a simple comment in the file which could be useful for those who have pnpm as engine.
Given pnpm does not generate a `packages-lock.json` the install step would fail and it would leave no other option.
The action `npm-install@v1` does not support `pnpm` and there's no action can do it today.

Replacing the install step would fix it easily.