### PR TITLE
Comment actions to v2

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -89,7 +89,7 @@ jobs:
           echo ::set-output name=body::$body
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@v2
         if: success() && github.event.number
         id: fc
         with:
@@ -97,14 +97,14 @@ jobs:
           body-includes: '<!-- __NEXTJS_BUNDLE -->'
 
       - name: Create Comment
-        uses: peter-evans/create-or-update-comment@v1.4.4
+        uses: peter-evans/create-or-update-comment@v2
         if: success() && github.event.number && steps.fc.outputs.comment-id == 0
         with:
           issue-number: ${{ github.event.number }}
           body: ${{ steps.get-comment-body.outputs.body }}
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v1.4.4
+        uses: peter-evans/create-or-update-comment@v2
         if: success() && github.event.number && steps.fc.outputs.comment-id != 0
         with:
           issue-number: ${{ github.event.number }}


### PR DESCRIPTION
Comment actions were old and using `set-output` which is now deprecated.

As per [GH note](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) the maintainer made the upgrade which is now reflected into the file.