### PR TITLE
Upload artifact to v3

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -48,7 +48,7 @@ jobs:
         run: npx -p nextjs-bundle-analysis report
 
       - name: Upload bundle
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bundle
           path: .next/analyze/__bundle_analysis.json


### PR DESCRIPTION
Upgrade the action `upload-artifact` to v3 in order to remove the warnings from desupported commands