### PR TITLE
feat: update template to use sticky-pull-request-comment

### DIFF
--- a/.changeset/eighty-rules-remember.md
+++ b/.changeset/eighty-rules-remember.md
@@ -1,0 +1,5 @@
+---
+'nextjs-bundle-analysis': patch
+---
+
+Update template to use [sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment)

--- a/compare.js
+++ b/compare.js
@@ -192,10 +192,6 @@ if (hasNoChanges) {
   output += 'This PR introduced no changes to the JavaScript bundle! 🙌'
 }
 
-// we add this tag so that our action can be able to easily and consistently find the
-// right comment to edit as more commits are pushed.
-output += `<!-- __NEXTJS_BUNDLE_${PACKAGE_NAME} -->`
-
 // however, if ignoreIfEmpty is true, set output to an empty string
 if (hasNoChanges && SKIP_COMMENT_IF_EMPTY) {
   output = ''

--- a/template.yml
+++ b/template.yml
@@ -104,26 +104,8 @@ jobs:
           echo "$(cat .next/analyze/__bundle_analysis_comment.txt)" >> $GITHUB_OUTPUT
           echo EOF >> $GITHUB_OUTPUT
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        if: success() && github.event.number
-        id: fc
+      - name: Comment
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          issue-number: ${{ github.event.number }}
-          body-includes: '<!-- __NEXTJS_BUNDLE -->'
-
-      - name: Create Comment
-        uses: peter-evans/create-or-update-comment@v2
-        if: success() && github.event.number && steps.fc.outputs.comment-id == 0
-        with:
-          issue-number: ${{ github.event.number }}
-          body: ${{ steps.get-comment-body.outputs.body }}
-
-      - name: Update Comment
-        uses: peter-evans/create-or-update-comment@v2
-        if: success() && github.event.number && steps.fc.outputs.comment-id != 0
-        with:
-          issue-number: ${{ github.event.number }}
-          body: ${{ steps.get-comment-body.outputs.body }}
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          edit-mode: replace
+          header: next-touched-pages
+          message: ${{ steps.get-comment-body.outputs.body }}

--- a/template.yml
+++ b/template.yml
@@ -107,5 +107,5 @@ jobs:
       - name: Comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          header: next-touched-pages
+          header: next-bundle-analysis
           message: ${{ steps.get-comment-body.outputs.body }}


### PR DESCRIPTION
This PR updates our template to use [sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment), which removes the need to manually embed a unique string into the generated comment.

