### PR TITLE
add collapsibleChangedPages option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ For example, if you build to `dist`, you should:
 
 (Optional, defaults to `false`) When set to `true`, if no pages have changed size the generated comment will be an empty string.
 
+### `collapsibleChangedPages (boolean)`
+
+(Optional, defaults to `false`) When set to `true`, changed pages table will be collapsible.
+
 ## Caveats
 
 - This plugin only analyzes the direct bundle output from next.js. If you have added any other scripts via the `<script>` tag, especially third party scripts and things like analytics or other tracking scripts, these are not included in the analysis. Scripts of this nature should _probably_ be loaded in behind a consent manager and should not make an impact on your initial load, and as long as this is how you handle them it should make no difference, but it's important to be aware of this and account for the extra size added by these scripts if they are present in your app.

--- a/compare.js
+++ b/compare.js
@@ -29,6 +29,7 @@ const SHOW_DETAILS =
 const BUILD_OUTPUT_DIRECTORY = getBuildOutputDirectory(options)
 const PACKAGE_NAME = options.name
 const SKIP_COMMENT_IF_EMPTY = options.skipCommentIfEmpty
+const COLLAPSIBLE_CHANGED_PAGES = options.collapsibleChangedPages
 
 // import the current and base branch bundle stats
 const currentBundle = require(path.join(
@@ -165,7 +166,8 @@ if (changedPages.length) {
 The following page${plural} changed size from the code in this PR compared to its base branch:
 
 `
-  output += markdownTable(changedPages, globalBundleCurrent, globalBundleBase)
+  const table = markdownTable(changedPages, globalBundleCurrent, globalBundleBase);
+  output += COLLAPSIBLE_CHANGED_PAGES ? `<details><summary>Changed page${plural}</summary>\n\n${table}\n</details>\n` : table
 
   // this details section is a bit more responsive, it will render slightly different
   // details depending on whether a budget is being used, since the information presented


### PR DESCRIPTION
This option allows us to make changed pages table collapsible. This would be helpful for developers to recognize impacted pages without being overwhelmed by a lengthy comment when the PR affects numerous pages.