### PR TITLE
Upgrade filesize to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "nextjs-bundle-analysis",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-bundle-analysis",
-      "version": "0.4.0",
-      "license": "GPL-2.0",
+      "version": "0.5.0",
+      "license": "MPL-2.0",
       "dependencies": {
-        "filesize": "^7.0.0",
+        "filesize": "^10.0.7",
         "gzip-size": "^6.0.0",
         "inquirer": "^8.1.1",
         "mkdirp": "^1.0.4",
@@ -3496,11 +3496,11 @@
       }
     },
     "node_modules/filesize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-7.0.0.tgz",
-      "integrity": "sha512-Wsstw+O1lZ9gVmOI1thyeQvODsaoId2qw14lCqIzUhoHKXX7T2hVpB7BR6SvgodMBgWccrx/y2eyV8L7tDmY6A==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.7.tgz",
+      "integrity": "sha512-iMRG7Qo9nayLoU3PNCiLizYtsy4W1ClrapeCwEgtiQelOAOuRJiw4QaLI+sSr8xr901dgHv+EYP2bCusGZgoiA==",
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">= 10.4.0"
       }
     },
     "node_modules/fill-range": {
@@ -11390,9 +11390,9 @@
       "dev": true
     },
     "filesize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-7.0.0.tgz",
-      "integrity": "sha512-Wsstw+O1lZ9gVmOI1thyeQvODsaoId2qw14lCqIzUhoHKXX7T2hVpB7BR6SvgodMBgWccrx/y2eyV8L7tDmY6A=="
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.7.tgz",
+      "integrity": "sha512-iMRG7Qo9nayLoU3PNCiLizYtsy4W1ClrapeCwEgtiQelOAOuRJiw4QaLI+sSr8xr901dgHv+EYP2bCusGZgoiA=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/hashicorp/nextjs-bundle-analysis#readme",
   "dependencies": {
-    "filesize": "^7.0.0",
+    "filesize": "^10.0.7",
     "gzip-size": "^6.0.0",
     "inquirer": "^8.1.1",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
This PR upgrades `filesize` to the latest version (from `v7` to `v10`)


**Note**
Changes have been tested (although PR #74 would be required to make them working - it's unrelated to the upgrade). I am proposing separate PRs for granular control