### PR TITLE
Upgrade mkdirp to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "nextjs-bundle-analysis",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-bundle-analysis",
-      "version": "0.4.0",
-      "license": "GPL-2.0",
+      "version": "0.5.0",
+      "license": "MPL-2.0",
       "dependencies": {
         "filesize": "^7.0.0",
         "gzip-size": "^6.0.0",
         "inquirer": "^8.1.1",
-        "mkdirp": "^1.0.4",
+        "mkdirp": "^3.0.1",
         "number-to-words": "^1.2.4"
       },
       "bin": {
@@ -5920,14 +5920,17 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mri": {
@@ -13196,9 +13199,9 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
     },
     "mri": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "filesize": "^7.0.0",
     "gzip-size": "^6.0.0",
     "inquirer": "^8.1.1",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^3.0.1",
     "number-to-words": "^1.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades `mkdirp` to the latest version (from `v1` to `v3`)

**Note**
Changes have been tested (although PR https://github.com/hashicorp/nextjs-bundle-analysis/pull/74 would be required to make them working - it's unrelated to the upgrade). I am proposing separate PRs for granular control