### PR TITLE
Use cache

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -37,9 +37,11 @@ jobs:
           node-version: 18
           cache: 'npm'
           # cache: 'pnpm'
+          # cache: 'yarn'
 
       - run: npm install
       # - run: pnpm install
+      # - run: yarn install --frozen-lockfile
 
       - name: Restore next build
         uses: actions/cache@v3

--- a/template.yml
+++ b/template.yml
@@ -26,22 +26,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # - name: Install pnpm
+      #   uses: pnpm/action-setup@v2
+      #   with:
+      #     version: 7
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
+          # cache: 'pnpm'
 
-      - name: Install dependencies
-        uses: bahmutov/npm-install@v1
-
-      # If pnpm is used, you need to switch the previous step with the following one. pnpm does not create a package-lock.json
-      # so the step above will fail to pull dependencies
-      # - uses: pnpm/action-setup@v2
-      #   name: Install pnpm
-      #   id: pnpm-install
-      #   with:
-      #     version: 7
-      #     run_install: true
+      - run: npm install
+      # - run: pnpm install
 
       - name: Restore next build
         uses: actions/cache@v3


### PR DESCRIPTION
This PR should use the NPM/PNPM/yarn caches which should dramatically reduce the time spent installing dependencies.

From https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data