### PR TITLE
Fix: update the existing comment instead of creating a new one

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -110,7 +110,7 @@ jobs:
         id: fc
         with:
           issue-number: ${{ github.event.number }}
-          body-includes: '<!-- __NEXTJS_BUNDLE -->'
+          body-includes: '<!-- __NEXTJS_BUNDLE'
 
       - name: Create Comment
         uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
When creating a comment we put an HTML comment inside, to use later to decide whether to update the existing comment or create a new one with this template `<!-- __NEXTJS_BUNDLE_${PACKAGE_NAME} -->`.

https://github.com/hashicorp/nextjs-bundle-analysis/blob/a4cf35f98ec1ecb5753ba966acde342fbd175319/compare.js#L195-L197

In the workflow we search for the comment but without the `${PACKAGE_NAME`.

https://github.com/hashicorp/nextjs-bundle-analysis/blob/a4cf35f98ec1ecb5753ba966acde342fbd175319/template.yml#L107-L113

This PR fixes the mismatch between the two
```diff
- body-includes: '<!-- __NEXTJS_BUNDLE_ -->'
+ body-includes: '<!-- __NEXTJS_BUNDLE'
```